### PR TITLE
Set Delay to 100ms when Delay is less than 20ms.

### DIFF
--- a/AnimatedImage/Formats/GifRenderer.cs
+++ b/AnimatedImage/Formats/GifRenderer.cs
@@ -267,7 +267,7 @@ namespace AnimatedImage.Formats
             }
             else
             {
-                end = begin + TimeSpan.FromMilliseconds(gce.Delay == 0 ? 100 : gce.Delay);
+                end = begin + TimeSpan.FromMilliseconds(gce.Delay < 20 ? 100 : gce.Delay);
                 method = (FrameDisposalMethod)gce.DisposalMethod;
                 transparencyIndex = gce.HasTransparency ? gce.TransparencyIndex : -1;
             }


### PR DESCRIPTION
GIF frames with Delay=1 for 100ms.
This is similar to the behavior of a web browser.