### PR TITLE
Fix IndexOutOfRange exception in indics generation

### DIFF
--- a/AnimatedImage/Formats/Gif/GifImageData.cs
+++ b/AnimatedImage/Formats/Gif/GifImageData.cs
@@ -132,10 +132,10 @@ namespace AnimatedImage.Formats.Gif
                     oldCode = inCode;
 
                     // Drain the pixel stack.
-                    do
+                    while (pixelIndex < TotalPixels && top > 0)
                     {
                         indics[pixelIndex++] = pixelStack[--top];
-                    } while (top > 0);
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixed an access exception outside the scope of indics that was occurring with some older GIFs.
I am not confident this is the correct way to handle this.