### PR TITLE
Restrict rectangle access to Bitmap to a range.

### DIFF
--- a/AnimatedImage.Wpf/WriteableBitmapFace.cs
+++ b/AnimatedImage.Wpf/WriteableBitmapFace.cs
@@ -20,13 +20,13 @@ namespace AnimatedImage.Wpf
 
         public void ReadBGRA(byte[] buffer, int x, int y, int width, int height)
         {
-            var bounds = new Int32Rect(x, y, width, height);
+            var bounds = new Int32Rect(x, y, Math.Min(width, Bitmap.PixelWidth - x), Math.Min(height, Bitmap.PixelHeight - y));
             Bitmap.CopyPixels(bounds, buffer, 4 * width, 0);
         }
 
         public void WriteBGRA(byte[] buffer, int x, int y, int width, int height)
         {
-            var bounds = new Int32Rect(x, y, width, height);
+            var bounds = new Int32Rect(x, y, Math.Min(width, Bitmap.PixelWidth - x), Math.Min(height, Bitmap.PixelHeight - y));
             Bitmap.WritePixels(bounds, buffer, 4 * width, 0);
         }
     }


### PR DESCRIPTION
Some old GIFs were causing an exception because rect was out of range of the Bitmap, so I fixed it so that it is now within the area.