### PR TITLE
Fixed WebP animation frame duration issue

### DIFF
--- a/AnimatedImage/Formats/WebpRenderer.cs
+++ b/AnimatedImage/Formats/WebpRenderer.cs
@@ -59,7 +59,7 @@ namespace AnimatedImage.Formats
             {
                 do
                 {
-                    var duration = Math.Max(iter.duration, 100);
+                    var duration = iter.duration <= 10 ? 100 : iter.duration;
                     TimeSpan end = begin + TimeSpan.FromMilliseconds(duration);
                     var frame = new WebpRendererFrame(0, 0, Width, Height, begin, end);
                     frames.Add(frame);


### PR DESCRIPTION
If it is less than 10ms, set it to 100ms. (Issue #25)
Adjusted to match web browser behavior.

## WebP Specification

from [WebP Container Specification](https://developers.google.com/speed/webp/docs/riff_container) :
> The time to wait before displaying the next frame, in 1-millisecond units. Note that the interpretation of the Frame Duration of 0 (and often <= 10) is defined by the implementation. Many tools and browsers assign a minimum duration similar to GIF.

## Animated WebP Frame Duration Samples

#### 10ms
![animation_10ms](https://github.com/user-attachments/assets/ebbabf13-4387-4c75-8703-731f1d1c8b83)

#### 11ms
![animation_11ms](https://github.com/user-attachments/assets/885514cc-256e-4ade-9b3e-60139bb1e0e8)

#### 100ms
![animation_100ms](https://github.com/user-attachments/assets/a0ea1088-848c-4b4c-a6c6-0a800a576489)
